### PR TITLE
Bugfixes

### DIFF
--- a/dev-build.sh
+++ b/dev-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# This script is used for dev purposes only.
+npm run build && cd dist/ngx-mat-timepicker && npm pack
+echo 'Build folder:'
+echo $(pwd)

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.html
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.html
@@ -4,7 +4,6 @@
        (ngModelChange)="onModelChange($event)"
        (input)="updateTime($event)"
        (keydown)="onInputKeydown($event)"
-       (focus)="saveTimeAndChangeTimeUnit($event, timeUnit)"
        (blur)="onBlur()"
        [ngxMatTimepickerAutofocus]="isActive"
        type="number"

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.ts
@@ -105,7 +105,17 @@ export class NgxMatTimepickerDialControlComponent implements OnInit {
             // Casting input value to a number is required to trim the leading '0'
             const value = (+target.value).toString();
             const isHoursControl = target.max === '23';
-            const properValueEntered = value <= target.max
+            const properValueEntered = +value <= +target.max && target.value.length < 3;
+            if (!properValueEntered) {
+                // If value is not valid, restore previous value
+                target.value = target.dataset['previousVal'];
+                const event = new Event('input', {
+                    bubbles: true,
+                });
+                target.dispatchEvent(event);
+                return;
+            }
+            target.dataset['previousVal'] = value;
             const enteredTwoDigits = value.length === 2;
             const firstDigisDifferentThanZero = value[0] !== '0';
 

--- a/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
+++ b/projects/ngx-mat-timepicker/src/lib/services/ngx-mat-timepicker.service.ts
@@ -55,8 +55,10 @@ export class NgxMatTimepickerService {
     private _period$ = new BehaviorSubject<NgxMatTimepickerPeriods>(NgxMatTimepickerPeriods.AM);
 
     getFullTime(format: number): string {
-        const selectedHour = this._hour$.getValue().time;
-        const selectedMinute = this._minute$.getValue().time;
+        const hourInput = document.querySelector('input[max="23"]');
+        const minuteInput = document.querySelector('input[max="59"]');
+        const selectedHour = hourInput ? +(document.querySelector('input[max="23"]') as HTMLInputElement).value : this._hour$.getValue().time;
+        const selectedMinute = minuteInput ? +(document.querySelector('input[max="59"]') as HTMLInputElement).value : this._minute$.getValue().time;
         const hour = selectedHour != null ? selectedHour : DEFAULT_HOUR.time;
         const minute = selectedMinute != null ? selectedMinute : DEFAULT_MINUTE.time;
         const period = format === 12 ? this._period$.getValue() : "";


### PR DESCRIPTION
- Prevent invalid value input, as requsted by Filip.
- Fix input focusing loop, the problem was caused by https://github.com/IterativeEngineering/ngx-mat-timepicker/commit/df60792a7f110eee082a1a01d8773f1c1b1fb55f:
[loop.webm](https://github.com/IterativeEngineering/ngx-mat-timepicker/assets/56605753/e0e8cbeb-620c-468f-ba8e-20d35d906508)
- Fix setting default value for minutes, sometimes `01` was set instead of `00`:
[Kapture 2024-05-24 at 15.59.07.webm](https://github.com/IterativeEngineering/ngx-mat-timepicker/assets/56605753/286751dd-608e-4a9e-9f8e-e99ef3034d09)
