### PR TITLE
Revert angular material package to v16

### DIFF
--- a/projects/ngx-mat-timepicker/package.json
+++ b/projects/ngx-mat-timepicker/package.json
@@ -34,7 +34,7 @@
     "@angular/compiler": "^17.0.0",
     "@angular/core": "^17.0.0",
     "@angular/forms": "^17.0.0",
-    "@angular/material": "^17.0.0",
+    "@angular/material": "^16.0.0",
     "@angular/platform-browser": "^17.0.0"
   }
 }


### PR DESCRIPTION
This is required to amend changing picker width on Safari