### PR TITLE
Fix null input listener in disabled dial control

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-timepicker-repo",
-  "version": "19.0.0",
+  "version": "19.0.0-iterative-1",
   "build": 0,
   "license": "MIT",
   "private": true,

--- a/projects/ngx-mat-timepicker/package.json
+++ b/projects/ngx-mat-timepicker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-mat-timepicker",
-  "version": "19.0.0",
+  "version": "19.0.0-iterative-1",
   "license": "MIT",
   "description": "ngx-mat-timepicker is an Angular material 9+ extension to add time pickers!",
   "homepage": "https://tonysamperi.github.io/ngx-mat-timepicker",

--- a/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.ts
+++ b/projects/ngx-mat-timepicker/src/lib/components/ngx-mat-timepicker-dial-control/ngx-mat-timepicker-dial-control.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, OnDestroy, Input, Output, ElementRef, AfterViewInit} from "@angular/core";
+import {Component, EventEmitter, OnDestroy, Input, Output, ElementRef, AfterViewInit, OnInit} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {NgIf, NgClass} from "@angular/common";
 //
@@ -8,9 +8,11 @@ import {NgxMatTimepickerParserPipe} from "../../pipes/ngx-mat-timepicker-parser.
 import {NgxMatTimepickerUtils} from "../../utils/ngx-mat-timepicker.utils";
 import {NgxMatTimepickerTimeLocalizerPipe} from "../../pipes/ngx-mat-timepicker-time-localizer.pipe";
 import {NgxMatTimepickerAutofocusDirective} from "../../directives/ngx-mat-timepicker-autofocus.directive";
-import { OnInit } from "@angular/core";
-
 function retainSelection(this: HTMLInputElement) {
+    if (this.type === "number") {
+        return;
+    }
+
     this.selectionStart = this.selectionEnd;
 }
 
@@ -29,6 +31,7 @@ function retainSelection(this: HTMLInputElement) {
     ]
 })
 export class NgxMatTimepickerDialControlComponent implements OnInit, AfterViewInit, OnDestroy {
+    private _dialInput: HTMLInputElement | null = null;
 
     private get _selectedTime(): NgxMatTimepickerClockFace | undefined {
         if (!!this.time) {
@@ -80,11 +83,17 @@ export class NgxMatTimepickerDialControlComponent implements OnInit, AfterViewIn
     }
 
     ngAfterViewInit(): void {
-        this._elRef.nativeElement.querySelector("input").addEventListener("select", retainSelection, false);
+        this._dialInput = this._elRef.nativeElement.querySelector("input");
+        if (this._dialInput) {
+            this._dialInput.addEventListener("select", retainSelection, false);
+        }
     }
 
     ngOnDestroy(): void {
-        this._elRef.nativeElement.querySelector("input").removeEventListener("select", retainSelection);
+        if (this._dialInput) {
+            this._dialInput.removeEventListener("select", retainSelection);
+            this._dialInput = null;
+        }
     }
 
     onKeydown(e: any): void {


### PR DESCRIPTION
Guard select listener setup/teardown in dial control so disabled mode (which renders a fake input) no longer crashes on ngAfterViewInit.
<img width="757" height="410" alt="Zrzut ekranu z 2026-02-27 14-21-44" src="https://github.com/user-attachments/assets/e991a183-24ef-4152-940b-0aea043971b8" />
